### PR TITLE
Disable --enable-small build option

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -349,7 +349,6 @@ RUN \
         --enable-libkvazaar \
         --enable-libaom --extra-libs=-lpthread \
         --enable-postproc \
-        --enable-small \
         --enable-version3 \
         --extra-cflags="-I${PREFIX}/include" \
         --extra-ldflags="-L${PREFIX}/lib" \


### PR DESCRIPTION
Loads all profile strings
https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/profiles.c#L24

Context:
https://github.com/jellyfin/jellyfin/issues/926#issuecomment-465046605