### PR TITLE
Add gnutls SSL support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,7 +70,7 @@ RUN      buildDeps="autoconf \
                     perl \
                     pkg-config \
                     python \
-                    libssl-dev \
+                    libgnutls28-dev \
                     yasm \
                     libva-dev \
                     zlib1g-dev" && \
@@ -325,6 +325,7 @@ RUN \
         --enable-avresample \
         --enable-libopencore-amrnb \
         --enable-libopencore-amrwb \
+        --enable-gnutls \
         --enable-gpl \
         --enable-libass \
         --enable-libfreetype \


### PR DESCRIPTION
Remove the openssl dep, add gnutls dep, add `--enable-gnutls`. Will reenable SSL support.

Fixes jellyfin/jellyfin#1015